### PR TITLE
PLATUI-2520 - adding filters for DAST related to Edge browser 

### DIFF
--- a/alert-filters.json
+++ b/alert-filters.json
@@ -1,0 +1,20 @@
+{
+  "add": [
+    {
+      "reason": "This issue is related to the Edge Browser and outside our scope",
+      "contextId": 1,
+      "url": "^.*microsoft.com.*",
+      "ruleId": 10021,
+      "newLevel": -1,
+      "urlIsRegex": true
+    },
+    {
+      "reason": "This issue is related to the Edge Browser and outside our scope",
+      "contextId": 1,
+      "url": "^.*bing.com.*",
+      "ruleId": 10021,
+      "newLevel": -1,
+      "urlIsRegex": true
+    }
+  ]
+}


### PR DESCRIPTION
URLs checked by DAST outside our scope and associated with Edge browser, not URLs being tested as part of a journey.