### PR TITLE
PLATUI-BAU: Update dependencies and plugins

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   val test: Seq[ModuleID] = Seq(
     "com.vladsch.flexmark" % "flexmark-all"   % "0.62.2" % Test,
-    "org.scalatest"       %% "scalatest"      % "3.2.16" % Test,
+    "org.scalatest"       %% "scalatest"      % "3.2.17" % Test,
     "org.slf4j"            % "slf4j-simple"   % "1.7.36" % Test,
     "uk.gov.hmrc"         %% "ui-test-runner" % "0.+"    % Test // Do NOT use .+ notation in test repositories
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,9 +3,9 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.14.0")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
 


### PR DESCRIPTION
Dependencies

- Update `scalatest` to version `3.2.17`

Plugins

- Update `sbt-auto-build` to version `3.14.0`
- Update `sbt-scalafmt` to version `2.5.2`